### PR TITLE
fix POMDP union action mapping

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -94,54 +94,73 @@ def run_subfamily(project_path, subfamily_size = 10, timeout = 60, num_nodes = 2
 def run_union(project_path):
     num_assignments = 10
     gd = POMDPFamiliesSynthesis(project_path, use_softmax=False, steps=10)
-    assignments = gd.create_random_subfamily(10)
+    assignments = gd.create_random_subfamily(num_assignments)
     # assignments = [pomdp_sketch.family.pick_random() for _ in range(num_assignments)]
     # [print(a) for a in assignments]
-    pomdps = [gd.assignment_to_pomdp(gd.pomdp_sketch,assignment)[0] for assignment in assignments]
-    print([pomdp for pomdp in pomdps])
-    # fsc = gd.solve_pomdp_paynt(pomdps[0], gd.pomdp_sketch.specification, 2, timeout=5)
-    # print(fsc)
-
-    # exit()
-
-
+    pomdps = []
+    # make sure that all POMDPs have the same action mapping so we can store only one copy
+    observation_action_to_true_action = None
+    for assignment in assignments:
+        pomdp,obs_action_to_true_action = gd.assignment_to_pomdp(gd.pomdp_sketch,assignment,restore_absorbing_states=False)
+        pomdps.append(pomdp)
+        if observation_action_to_true_action is None:
+            observation_action_to_true_action = obs_action_to_true_action
+        else:
+            assert observation_action_to_true_action == obs_action_to_true_action
+    # [print(pomdp) for pomdp in pomdps]
 
     union_pomdp = payntbind.synthesis.createModelUnion(pomdps)
-    print(union_pomdp)
 
     nodes = 2
     fsc = gd.solve_pomdp_paynt(union_pomdp, gd.pomdp_sketch.specification, nodes, timeout=5)
+
+    # get rid of the fresh observation
     initial_node = fsc.update_function[0][-1]
-    print("initial node is:", initial_node)
-    print(fsc)
     for n in range(nodes):
         fsc.action_function[n] = fsc.action_function[n][:-1]
         assert len(fsc.action_function[n]) == gd.nO
         fsc.update_function[n] = fsc.update_function[n][:-1]
         assert len(fsc.update_function[n]) == gd.nO
-
-    if initial_node == 1:
-        action_function = [None] * nodes
-        update_function = [None] * nodes
-        for n in range(nodes):
-            action_function[n] = fsc.action_function[(n+1) % 2]
-            assert len(action_function[n]) == gd.nO
-            update_function[n] = [(m+1) % nodes for m in fsc.update_function[(n+1) % 2]] # TODO
-            assert len(update_function[n]) == gd.nO
-        fsc.action_function = action_function
-        fsc.update_function = update_function
     fsc.num_observations -= 1
-    print(fsc)
-    print(gd.pomdp_sketch.observation_to_actions)
 
-    print(gd.nO)
+    # ensure that 0 is the initial node
+    fsc_update_to_pomdp_update = list(range(nodes))
+    if initial_node != 0:
+        fsc_update_to_pomdp_update[0] = initial_node
+        fsc_update_to_pomdp_update[initial_node] = 0
+        tmp = fsc.action_function[0]; fsc.action_function[0] = fsc.action_function[initial_node]; fsc.action_function[initial_node] = tmp
+        tmp = fsc.update_function[0]; fsc.update_function[0] = fsc.update_function[initial_node]; fsc.update_function[initial_node] = tmp
+
+    # ensure that FSC uses the same ordering of action labels as the POMDP sketch
+    for n in range(nodes):
+        for o in range(fsc.num_observations):
+            action_label = fsc.action_labels[fsc.action_function[n][o]]
+            fsc.action_function[n][o] = gd.pomdp_sketch.action_labels.index(action_label)
+    fsc.action_labels = gd.pomdp_sketch.action_labels.copy()
+
+    # map FSC actions to true sketch actions
+    for n in range(nodes):
+        for o in range(fsc.num_observations):
+            fsc_action = fsc.action_function[n][o]
+            fsc_action_label = fsc.action_labels[fsc_action]
+            true_action_label = observation_action_to_true_action[o][fsc_action_label]
+            fsc_action = fsc.action_labels.index(true_action_label)
+            fsc.action_function[n][o] = fsc_action
+
+    fsc.check(gd.pomdp_sketch.observation_to_actions)
+    exit()
+    # TODO make FSC stochastic ?
+
+    print(gd.pomdp_sketch.observation_to_actions)
 
     print(gd.get_values_on_subfamily(gd.get_dtmc_sketch(fsc), assignments))
 
 # run_family()
 # run_family_softmax(OBSTACLES_TEN_TWO)
 # run_family_experiment()
-run_subfamily(ROVER, timeout=30)
+# run_subfamily(ROVER, timeout=30)
 # for env, timeout in zip(ENVS, [10, 10, 60]):
     # run_subfamily(env, timeout=timeout)
 # run_subfamily(num_nodes=3, timeout=60)
+
+run_union(OBSTACLES_TEN_TWO)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -124,31 +124,32 @@ def run_union(project_path):
     fsc.num_observations -= 1
 
     # ensure that 0 is the initial node
-    fsc_update_to_pomdp_update = list(range(nodes))
+    fsc_update_fixed = list(range(nodes))
     if initial_node != 0:
-        fsc_update_to_pomdp_update[0] = initial_node
-        fsc_update_to_pomdp_update[initial_node] = 0
+        fsc_update_fixed[0] = initial_node
+        fsc_update_fixed[initial_node] = 0
         tmp = fsc.action_function[0]; fsc.action_function[0] = fsc.action_function[initial_node]; fsc.action_function[initial_node] = tmp
         tmp = fsc.update_function[0]; fsc.update_function[0] = fsc.update_function[initial_node]; fsc.update_function[initial_node] = tmp
+    for n in range(nodes):
+        for o in range(fsc.num_observations):
+            fsc.action_function[n][o] = fsc_update_fixed[fsc.action_function[n][o]]
 
-    # ensure that FSC uses the same ordering of action labels as the POMDP sketch
+    # ensure that FSC uses the same ordering of action labels as the POMDP sketch (required by fsc.check())
     for n in range(nodes):
         for o in range(fsc.num_observations):
             action_label = fsc.action_labels[fsc.action_function[n][o]]
             fsc.action_function[n][o] = gd.pomdp_sketch.action_labels.index(action_label)
     fsc.action_labels = gd.pomdp_sketch.action_labels.copy()
 
-    # map FSC actions to true sketch actions
+    # fix possibly dummy actions
     for n in range(nodes):
         for o in range(fsc.num_observations):
-            fsc_action = fsc.action_function[n][o]
-            fsc_action_label = fsc.action_labels[fsc_action]
+            fsc_action_label = fsc.action_labels[fsc.action_function[n][o]]
             true_action_label = observation_action_to_true_action[o][fsc_action_label]
-            fsc_action = fsc.action_labels.index(true_action_label)
-            fsc.action_function[n][o] = fsc_action
+            fsc.action_function[n][o] = fsc.action_labels.index(true_action_label)
 
     fsc.check(gd.pomdp_sketch.observation_to_actions)
-    exit()
+    return
     # TODO make FSC stochastic ?
 
     print(gd.pomdp_sketch.observation_to_actions)


### PR DESCRIPTION
This should fix the problem with incorrect action selection by FSC synthesized for the POMDP union. While the POMDP union construction is correct, it comprises POMDPs created by `assignment_to_pomdp` that enables all actions, while the `observation_action_to_true_action` map was ignored. The updated code takes this map into account and performs some additional FSC transformations to make it compatible with the POMDP sketch.